### PR TITLE
Remove hooks.yaml to supress pre-commit warning message

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -1,6 +1,0 @@
-- id: shell-lint
-  name: Shell Syntax Check
-  description: Check Shell Syntax on ALL staged files with user friendly messages and colors
-  entry: pre_commit_hooks/shell-lint.sh
-  language: script
-  files: (\.sh|\.zsh|\.ksh)$


### PR DESCRIPTION
Was previously seeing:

```
[WARNING] git://github.com/detailyang/pre-commit-shell uses legacy hooks.yaml to provide hooks.
In newer versions, this file is called .pre-commit-hooks.yaml
This will work in this version of pre-commit but will be removed at a later time.
If `pre-commit autoupdate` does not silence this warning consider making an issue / pull request.
```