### PR TITLE
Match files on type instead of extension

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
   description: Check Shell Syntax on ALL staged files with user friendly messages and colors
   entry: pre_commit_hooks/shell-lint.sh
   language: script
-  files: (\.sh|\.zsh|\.ksh)$
+  types: [shell]


### PR DESCRIPTION
This solves the problem where a executable shell scripts without an extension would be missed.