### PR TITLE
Fix: add alias to check

### DIFF
--- a/pre_commit_hooks/shell-lint.sh
+++ b/pre_commit_hooks/shell-lint.sh
@@ -7,7 +7,7 @@ set -o nounset
 DEBUG=${DEBUG:=0}
 [[ "$DEBUG" = "1" ]] && set -o xtrace
 
-if ! command which shellcheck &>/dev/null; then
+if ! command which shellcheck &>/dev/null && ! alias shellcheck &>/dev/null; then
   >&2 echo 'shellcheck command not found'
   exit 1
 fi


### PR DESCRIPTION
Adding support for aliased shellcheck command. Which allows to use docker images for checks.